### PR TITLE
fixed "fluid.html.html" typo; restored missing landing page content

### DIFF
--- a/content/index.html
+++ b/content/index.html
@@ -11,5 +11,5 @@ description: Test description
 
 [hyde-bootstrap](http://github.com/auzigog/hyde-bootstrap/) is a layout for Hyde based on the Bootstrap framework.
 
-This particular page is based on Bootstrap's [fluid.html.html](http://twitter.github.io/bootstrap/examples/fluid.html) example.
+This particular page is based on Bootstrap's [fluid.html](http://twitter.github.io/bootstrap/examples/fluid.html) example.
 {% endblock main %}

--- a/content/landing.html
+++ b/content/landing.html
@@ -19,7 +19,7 @@ description: Test description
     presentation layer. So this is more of an example of what not to do. I just didn't want to clutter the layouts
     folder any more.
  #}
-{% block content %}
+{% block container %}
   <!-- Example row of columns -->
 <!-- Main hero unit for a primary marketing message or call to action -->
   <div class="hero-unit">
@@ -45,4 +45,4 @@ description: Test description
       <p><a class="btn" href="#">View details &raquo;</a></p>
     </div>
   </div>
-{% endblock content %}
+{% endblock container %}


### PR DESCRIPTION
Hi,
I've just started working with the hyde-bootstrap template, and it's great. Thank you!

I've fixed a couple of things:
1. in index.html, "fluid.html" had the file extension shown twice ("fluid.html.html")
2. most of landing.html was missing for me (using hyde 0.8.7), but changing "content" to "container" fixed it.

Thanks again for providing this template, I've found it very useful.

Cheers,
Heather
